### PR TITLE
[CONV] trim unncesary conv state

### DIFF
--- a/lm_engine/modeling_utils/depthwise_causal_convolution.py
+++ b/lm_engine/modeling_utils/depthwise_causal_convolution.py
@@ -48,9 +48,12 @@ def _zeros_like_with_backward(x: torch.Tensor) -> torch.Tensor:
 
 
 def _get_last_state(x: torch.Tensor, kernel_size: int) -> torch.Tensor:
-    """Return the convolution carry as the latest kernel_size raw inputs."""
+    """Return the convolution carry as the latest kernel_size - 1 raw inputs (the state size used throughout
+    this module - kernel_size taps need only kernel_size - 1 history positions plus the current input)."""
 
-    # last kernel_size columns of x as passed, not of the original block
+    # last (kernel_size - 1) columns of x as passed, not of the original block.
+    kernel_size -= 1
+
     if x.size(-1) < kernel_size:
         return F.pad(x, (kernel_size - x.size(-1), 0))
 
@@ -67,6 +70,8 @@ class DepthwiseCausalConvolution(nn.Conv1d):
         std: float | None,
         use_padding_free_transformer: bool,
     ) -> DepthwiseCausalConvolution:
+        assert kernel_size > 1
+
         if use_padding_free_transformer:
             raise NotImplementedError()
 
@@ -131,7 +136,7 @@ class DepthwiseCausalConvolution(nn.Conv1d):
             if output_state:
                 final_state = _get_last_state(x, self.kernel_size)
 
-            initial_state_T = input_state.transpose(-1, -2) if input_state is not None else None
+            initial_state_T = None if input_state is None else input_state.transpose(-1, -2)
 
             if is_kernel_allowed(Kernel.causal_conv1d):
                 x = causal_conv1d_fn(
@@ -179,23 +184,23 @@ class DepthwiseCausalConvolution(nn.Conv1d):
                     if not self.use_activation_inside_kernel:
                         x = self.activation_function(x)
                 else:
-                    final_state = input_state.roll(shifts=-1, dims=-1)
-                    final_state[..., -1] = x[:, 0]
+                    # input_state: (B, H, K - 1); window: (B, H, K) = input_state's K - 1 history positions
+                    # followed by the one new position, i.e. the exact K raw taps this output depends on.
+                    window = torch.cat([input_state, x[:, 0][..., None]], dim=-1)
 
-                    x = (final_state * self.weight.squeeze(1)).sum(dim=-1)
+                    x = (window * self.weight.squeeze(1)).sum(dim=-1)
                     x = x[:, None, :]
                     if self.bias is not None:
                         x = x + self.bias
 
-                    if not output_state:
-                        final_state = None
+                    # drop the now-oldest position (was input_state[..., 0]) to get back to (B, H, K - 1)
+                    final_state = window[..., 1:] if output_state else None
 
                     x = self.activation_function(x)
             else:
                 x = x.transpose(-1, -2)
-                # TODO(zhonglin): add fused multi-token continuation support for
-                # input_state=[batch, dim, kernel_size] and
-                # final_state=[batch, dim, kernel_size].
+                # TODO: add fused multi-token continuation support for input_state=[batch, dim, kernel_size - 1]
+                # and final_state=[batch, dim, kernel_size - 1]
                 x = torch.cat([input_state, x], dim=-1)
 
                 if output_state:

--- a/lm_engine/modeling_utils/sequence_mixer_blocks/softmax_attention/config.py
+++ b/lm_engine/modeling_utils/sequence_mixer_blocks/softmax_attention/config.py
@@ -2,8 +2,6 @@
 # Copyright (c) 2026, Mayank Mishra
 # **************************************************
 
-from __future__ import annotations
-
 from typing import Any
 
 from ....arguments import BaseArgs

--- a/tests/context_parallel/depthwise_causal_convolution_cp_test.py
+++ b/tests/context_parallel/depthwise_causal_convolution_cp_test.py
@@ -12,7 +12,7 @@ from lm_engine.utils import is_causal_conv1d_available
 from ..utils import skip_test_if_device_unavailable, slow_test
 
 
-@pytest.mark.parametrize("kernel_size", list(range(1, 5)))
+@pytest.mark.parametrize("kernel_size", list(range(2, 5)))
 @pytest.mark.parametrize("use_causal_conv1d", [False, True])
 @slow_test
 def test_depthwise_causal_convolution_cp(kernel_size: int, use_causal_conv1d: bool) -> None:
@@ -20,9 +20,6 @@ def test_depthwise_causal_convolution_cp(kernel_size: int, use_causal_conv1d: bo
 
     if use_causal_conv1d and not is_causal_conv1d_available():
         pytest.skip("causal_conv1d unavailable")
-
-    if use_causal_conv1d and kernel_size == 1:
-        pytest.skip("causal_conv1d only supports kernel_size between 2 and 4")
 
     gpus_per_node = torch.cuda.device_count()
     if gpus_per_node < 2:

--- a/tests/depthwise_causal_convolution_test.py
+++ b/tests/depthwise_causal_convolution_test.py
@@ -71,7 +71,7 @@ def test_prefill_shapes(
 
     if output_state:
         assert state is not None
-        assert state.size() == (_BATCH, _HIDDEN_SIZE, kernel_size)
+        assert state.size() == (_BATCH, _HIDDEN_SIZE, kernel_size - 1)
     else:
         assert state is None
 

--- a/tests/depthwise_causal_convolution_test.py
+++ b/tests/depthwise_causal_convolution_test.py
@@ -126,7 +126,7 @@ def test_zero_state_matches_fresh_prefill(
     conv.eval()
 
     x = torch.randn(_BATCH, seq_len, _HIDDEN_SIZE, device=device)
-    zero_state = torch.zeros(_BATCH, _HIDDEN_SIZE, kernel_size, device=device)
+    zero_state = torch.zeros(_BATCH, _HIDDEN_SIZE, kernel_size - 1, device=device)
 
     out_fresh, state_fresh = conv(x, input_state=None, attention_mask=None, output_state=True)
     out_zero, state_zero = conv(x, input_state=zero_state, attention_mask=None, output_state=True)

--- a/tests/depthwise_causal_convolution_test.py
+++ b/tests/depthwise_causal_convolution_test.py
@@ -33,7 +33,7 @@ def _make_conv(
 
 
 @pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("cuda")])
-@pytest.mark.parametrize("kernel_size", [1, 4])
+@pytest.mark.parametrize("kernel_size", [4])
 @pytest.mark.parametrize("add_bias", [False, True])
 @pytest.mark.parametrize("activation", [None, "silu", "gelu"])
 @pytest.mark.parametrize("output_state", [False, True])
@@ -77,7 +77,7 @@ def test_prefill_shapes(
 
 
 @pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("cuda")])
-@pytest.mark.parametrize("kernel_size", [1, 4])
+@pytest.mark.parametrize("kernel_size", [4])
 @pytest.mark.parametrize("add_bias", [False, True])
 @pytest.mark.parametrize("activation", [None, "silu", "gelu"])
 @pytest.mark.parametrize("output_state", [False, True])
@@ -107,7 +107,7 @@ def test_generation_shapes(
 
 
 @pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("cuda")])
-@pytest.mark.parametrize("kernel_size", [1, 4])
+@pytest.mark.parametrize("kernel_size", [4])
 @pytest.mark.parametrize("add_bias", [False, True])
 @pytest.mark.parametrize("activation", [None, "silu", "gelu"])
 @pytest.mark.parametrize("seq_len", [1, 2, 4])
@@ -136,7 +136,7 @@ def test_zero_state_matches_fresh_prefill(
 
 
 @pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("cuda")])
-@pytest.mark.parametrize("kernel_size", [1, 4])
+@pytest.mark.parametrize("kernel_size", [4])
 @pytest.mark.parametrize("add_bias", [False, True])
 @pytest.mark.parametrize("activation", [None, "silu", "gelu"])
 @pytest.mark.parametrize("continuation_len", [1, 2, 4])
@@ -198,7 +198,7 @@ def test_consistency(
 
 
 @pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("cuda")])
-@pytest.mark.parametrize("kernel_size", [1, 4])
+@pytest.mark.parametrize("kernel_size", [4])
 def test_attention_mask(device: torch.device, kernel_size: int) -> None:
     skip_test_if_device_unavailable(device)
     conv = _make_conv(kernel_size=kernel_size, activation=None).to(device)
@@ -227,7 +227,7 @@ def test_attention_mask(device: torch.device, kernel_size: int) -> None:
 
 
 @pytest.mark.parametrize("device", [torch.device("cpu"), torch.device("cuda")])
-@pytest.mark.parametrize("kernel_size", [1, 4])
+@pytest.mark.parametrize("kernel_size", [4])
 @pytest.mark.parametrize("activation", [None, "silu", "gelu"])
 def test_kernel_vs_fallback(device: torch.device, kernel_size: int, activation: str | None) -> None:
     skip_test_if_device_unavailable(device)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved causal convolution behavior when processing single-token continuations.
  - Preserved convolution history correctly across successive operations.
  - Added validation to reject unsupported kernel sizes of 1 with a clear initialization error.

- **Compatibility**
  - Updated accelerated model support to align with the latest convolution behavior.
  - Refined handling of empty or uninitialized convolution state for more reliable execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->